### PR TITLE
Lower Python version requirement from 3.12 to 3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
     Topic :: Communications :: Email
@@ -25,12 +27,12 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >= 3.12
+python_requires = >= 3.10
 install_requires =
     aiosmtpd
 
 [options.packages.find]
-exclude = 
+exclude =
     tests
 
 [options.entry_points]


### PR DESCRIPTION
- Update python_requires in setup.cfg from >= 3.12 to >= 3.10
- Add Python 3.10 and 3.11 classifiers to support broader compatibility
- Fixes compatibility with Ubuntu 22.04 and other systems using Python 3.10

Fixes #17