### PR TITLE
Fix crash when directory exists but is not yet a valid Maildir

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Usage
 -----
 
 ::
-    
+
     $ dsmtpd -p 1025 -i 127.0.0.1
     2013-01-13 14:00:07,346 INFO: Starting SMTP server at 127.0.0.1:1025
 
@@ -43,6 +43,22 @@ Here is a small example::
     dsmtpd
 
     swaks --from stephane@wirtel.be --to foo@bar.com  --server localhost --port 1025
+
+Exit Codes
+----------
+
+``dsmtpd`` uses specific exit codes to indicate the result of its execution.
+
++------+---------------------------+--------------------------------------------+
+| Code | Meaning                   | Example                                    |
++======+===========================+============================================+
+| 0    | Success                   | Normal shutdown (e.g. user pressed         |
+|      |                           | ``Ctrl+C``) or clean termination.          |
++------+---------------------------+--------------------------------------------+
+| 2    | Invalid Maildir directory | The given path exists but does not contain |
+|      |                           | the required subfolders: ``tmp``, ``new``, |
+|      |                           | and ``cur``.                               |
++------+---------------------------+--------------------------------------------+
 
 Contributing
 ------------

--- a/dsmtpd/_dsmtpd.py
+++ b/dsmtpd/_dsmtpd.py
@@ -44,6 +44,26 @@ def create_maildir(maildir, create=True):
     finally:
         mbox.unlock()
 
+def ensure_maildir(path):
+    """
+    Ensure that *path* is a valid Maildir root.
+    If *path* does not exist, create a fresh Maildir (tmp/new/cur).
+    If *path* exists, create any missing subfolders without wiping content.
+    """
+    # If path doesn't exist at all → let mailbox.Maildir create the full layout.
+    if not os.path.exists(path):
+        mailbox.Maildir(path, create=True)
+        return
+
+    for sub in ("tmp", "new", "cur"):
+        os.makedirs(os.path.join(path, sub), exist_ok=True)
+
+def is_maildir(path):
+    "Quick structural check for a Maildir root."
+    return all(
+        os.path.isdir(os.path.join(path, sub))
+        for sub in ("tmp", "new", "cur")
+    )
 
 class DsmtpdHandler(Mailbox):
     async def handle_DATA(self, server, session, envelope):
@@ -108,19 +128,31 @@ def main():
         )
 
         if opts.directory:
-            try:
-                with create_maildir(opts.directory) as maildir:
-                    if len(maildir) > 0:
-                        log.info(
-                            "Found a Maildir storage with {} mails".format(len(maildir))
-                        )
-            except:
+            # Make sure it's a valid Maildir, whether or not the path already exists.
+            ensure_maildir(opts.directory)
+
+            # Double-check structure (defensive) and log a helpful error if not OK.
+            if not is_maildir(opts.directory):
                 log.fatal(
-                    "{} must be either non-existing (at a place where "
-                    "it can be created) or an existing Maildir "
-                    "storage".format(opts.directory)
+                    "%s must be either non-existing (so it can be created) or an existing Maildir (tmp/new/cur).",
+                    opts.directory,
                 )
-                raise
+                return 2
+
+            # Safely open and count messages (no crash if the dir previously lacked subdirs).
+            with create_maildir(opts.directory, create=False) as maildir:
+                try:
+                    counter = len(maildir)
+                except FileNotFoundError as exc:
+                    # Extremely defensive: repair and retry once.
+                    log.warning("Repairing Maildir layout after FileNotFoundError: %s", exc)
+                    ensure_maildir(opts.directory)
+                    counter = len(maildir)
+
+                if counter > 0:
+                    log.info(
+                        "Found a Maildir storage with {} mails".format(counter)
+                    )
 
             log.info("Storing the incoming emails into {}".format(opts.directory))
         controller = Controller(DsmtpdHandler(opts.directory), hostname=opts.interface, port=opts.port, data_size_limit=opts.max_size)


### PR DESCRIPTION
- Add ensure_maildir() function to create missing Maildir subdirectories (tmp/new/cur) without destroying existing content when a directory exists but lacks proper structure
- Add is_maildir() function to validate Maildir structure before processing
- Replace fragile try/except block with proper Maildir validation and repair logic
- Add defensive FileNotFoundError handling with automatic repair and retry
- Return exit code 2 when directory is invalid instead of crashing
- Update README.rst with exit codes documentation explaining when code 2 is returned
- Remove trailing whitespace in README.rst

This prevents crashes when users point dsmtpd at existing directories that aren't properly formatted Maildirs, gracefully converting them or providing clear error messages.

Fixes #18