### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Development improvements:
 - Significantly faster repeated test runs with timestamp-based dependency tracking
 - Add comprehensive tests for the debugging SMTP server (#8)
 - New integration tests for email reception, storage, and multipart email handling
+- Add support for Python 3.14 (#25)
 
 Version 1.1
 -----------

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ dsmptd: A debugger SMTP server for Humans
 
 dsmtpd is a small tool to help the developer without an smtp server
 
+**Python Support:** Python 3.10, 3.11, 3.12, 3.13, 3.14
+
 Usage
 -----
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Communications :: Email
 
 [options]


### PR DESCRIPTION
## Summary

- Update GitHub Actions workflow to include Python 3.14 in test matrix
- Add `Programming Language :: Python :: 3.14` classifier to setup.cfg
- Document Python 3.14 support in README.rst with version list
- Add changelog entry in CHANGES.rst

## Test plan

- [ ] Verify GitHub Actions workflow runs successfully with Python 3.14
- [ ] Confirm all tests pass on Python 3.14
- [ ] Verify package metadata correctly declares Python 3.14 support

Fixes #25