### PR TITLE
Replace deprecated license classifiers with SPDX license expression

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Development improvements:
 - Add comprehensive tests for the debugging SMTP server (#8)
 - New integration tests for email reception, storage, and multipart email handling
 - Add support for Python 3.14 (#25)
+- Replace deprecated license classifiers with SPDX license expression (#24)
 
 Version 1.1
 -----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,12 +10,11 @@ author_email = stephane@wirtel.be
 project_urls =
     Source = https://github.com/matrixise/dsmtpd
     Tracker = https://github.com/matrixise/dsmtpd/issues
-license = BSD
+license = BSD-2-Clause
 classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: Developers
-    License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.10


### PR DESCRIPTION
## Summary

This PR fixes the setuptools deprecation warning about license classifiers by adopting the modern SPDX license expression format.

## Changes

- Change `license` field from `"BSD"` to `"BSD-2-Clause"` (official SPDX identifier)
- Remove deprecated `License :: OSI Approved :: BSD License` classifier from classifiers list
- Add changelog entry documenting this change

## Why BSD-2-Clause?

Based on the LICENSE file, this project uses the Simplified BSD License (2-Clause), which only contains:
1. Copyright notice retention requirement for source redistributions
2. Copyright notice reproduction requirement for binary redistributions

This matches the SPDX identifier `BSD-2-Clause`.

## Testing

- [ ] Package builds without setuptools deprecation warnings
- [ ] License metadata is correctly recognized by packaging tools

Fixes #24