### PR TITLE
Fix SMTPUTF8 test to actually test non-ASCII email addresses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,12 +6,7 @@ Here you can see the full list of changes between each dsmtpd release.
 Unreleased
 ----------
 
-Testing improvements:
-
-- Fix SMTPUTF8 test to actually test non-ASCII email addresses (#40)
-- Test now uses real UTF-8 addresses (expéditeur@société.fr, destinataire@例え.jp)
-- Properly validates that SMTPUTF8 (RFC 6531) works with non-ASCII email addresses
-- Previous test only checked UTF-8 content in message body with ASCII addresses
+- Fix SMTPUTF8 test to actually exercise non-ASCII email addresses (RFC 6531) (#40)
 
 Version 1.2.0
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,16 @@ dsmtpd Changelog
 
 Here you can see the full list of changes between each dsmtpd release.
 
+Unreleased
+----------
+
+Testing improvements:
+
+- Fix SMTPUTF8 test to actually test non-ASCII email addresses (#40)
+- Test now uses real UTF-8 addresses (expéditeur@société.fr, destinataire@例え.jp)
+- Properly validates that SMTPUTF8 (RFC 6531) works with non-ASCII email addresses
+- Previous test only checked UTF-8 content in message body with ASCII addresses
+
 Version 1.2.0
 -------------
 

--- a/tests/test_server_integration.py
+++ b/tests/test_server_integration.py
@@ -339,23 +339,24 @@ def test_smtputf8_support():
         controller.start()
 
         try:
-            # Send email with UTF-8 characters in addresses
+            # Send email with UTF-8 characters in email addresses (RFC 6531)
             with smtplib.SMTP("127.0.0.1", 10033) as smtp:
                 # Verify SMTPUTF8 is announced in EHLO response
                 smtp.ehlo()
                 assert "smtputf8" in smtp.esmtp_features
 
-                sender = "user@example.com"
-                # Use UTF-8 recipient (using valid ASCII for actual test)
-                # Real UTF-8 addresses would require SMTPUTF8 MAIL FROM option
-                recipients = ["recipient@example.com"]
-                # Encode message as UTF-8 bytes to send Unicode content
-                message = (
-                    b"Subject: UTF-8 Test\r\n\r\n"
-                    b"Test message with UTF-8: \xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e"
-                )
+                # Use non-ASCII characters in email addresses
+                # This is what SMTPUTF8 (RFC 6531) is actually for
+                from email.message import EmailMessage
 
-                smtp.sendmail(sender, recipients, message)
+                msg = EmailMessage()
+                msg["From"] = "expéditeur@société.fr"
+                msg["To"] = "destinataire@例え.jp"
+                msg["Subject"] = "Test SMTPUTF8"
+                msg.set_content("Test message with UTF-8 content: 日本語")
+
+                # send_message automatically uses SMTPUTF8 when needed
+                smtp.send_message(msg)
 
             time.sleep(0.1)
 
@@ -363,12 +364,31 @@ def test_smtputf8_support():
             mbox = mailbox.Maildir(maildir, create=False)
             assert len(mbox) == 1
 
-            # Verify UTF-8 content
+            # Verify UTF-8 addresses and content are preserved
             email = mbox[list(mbox.keys())[0]]
-            assert "UTF-8 Test" in email["Subject"]
+            assert email["Subject"] == "Test SMTPUTF8"
+
+            # Verify UTF-8 addresses in SMTP envelope headers (X-MailFrom, X-RcptTo)
+            # These are added by dsmtpd and contain the actual SMTP envelope addresses
+            # which properly support UTF-8 with SMTPUTF8 (RFC 6531)
+            from email.header import decode_header
+
+            # Decode MIME-encoded headers
+            def decode_mime_header(header_value):
+                decoded_parts = decode_header(str(header_value))
+                return "".join(
+                    part.decode(encoding or "utf-8") if isinstance(part, bytes) else part
+                    for part, encoding in decoded_parts
+                )
+
+            mail_from = decode_mime_header(email["X-MailFrom"])
+            rcpt_to = decode_mime_header(email["X-RcptTo"])
+            assert "expéditeur" in mail_from and "société" in mail_from
+            assert "destinataire" in rcpt_to and "例え" in rcpt_to
+
             # Verify UTF-8 content is preserved in the stored email
-            payload = email.get_payload()
-            assert "UTF-8" in payload or "日本語" in payload
+            payload = email.get_payload(decode=True).decode("utf-8")
+            assert "日本語" in payload
 
         finally:
             controller.stop()


### PR DESCRIPTION
## Summary

Fixes the `test_smtputf8_support` test to actually test SMTPUTF8 (RFC 6531) functionality by using non-ASCII characters in email addresses, not just in message bodies.

## Background

As pointed out in issue #5, the previous test claimed to test SMTPUTF8 support but only used ASCII email addresses (`user@example.com`, `recipient@example.com`) and UTF-8 characters in the message body. This doesn't test what SMTPUTF8 is designed for.

**SMTPUTF8 (RFC 6531)** allows non-ASCII characters in email addresses themselves, such as:
- `prénom@société.fr` (French accented characters)
- `usuario@例え.jp` (Japanese characters)

## Changes

- **Use actual non-ASCII email addresses**: `expéditeur@société.fr` and `destinataire@例え.jp`
- **Use EmailMessage**: Switched from manual message construction to `EmailMessage` which uses modern email policy and properly handles SMTPUTF8
- **Automatic SMTPUTF8**: Use `send_message()` which automatically enables SMTPUTF8 when non-ASCII addresses are detected
- **Verify envelope addresses**: Check the `X-MailFrom` and `X-RcptTo` headers added by dsmtpd, which contain the actual SMTP envelope addresses
- **Proper header decoding**: Add MIME header decoding to correctly verify UTF-8 content

## Test Results

All tests pass:
```
tests/test_server_integration.py::test_smtputf8_support PASSED
```

The test now properly verifies that:
1. SMTPUTF8 is announced in EHLO response
2. Non-ASCII email addresses are accepted
3. UTF-8 addresses are correctly preserved in envelope headers
4. UTF-8 content is preserved in message body

## Related

Addresses feedback on issue #5