### PR TITLE
Drop `aiosmtpd` and `wheel` from direct build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "aiosmtpd"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
`wheel` was never needed (used to be pulled in by `setuptools` through the PEP 517 hook, now is a part of it), I've fixed the corresponding docs snippets in `setuptools`' docs but the wrong example still makes its way into projects incorrectly.

`aiosmtpd` was never needed for building the dists either. `setup.py` doesn't have anything that would invoke it.