### PR TITLE
Add Sviatoslav Sydorenko to AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Contributors
 
 - Bernhard E. Reiter <bernhard.reiter+github@intevation.de>
 - Sebastian Wagner <sebastian.wagner@commongoodtechnology.org>
+- Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>


### PR DESCRIPTION
## Summary

- Add Sviatoslav Sydorenko (`webknjaz`) to the `Contributors` list in `AUTHORS`.
- He authored PR #41 (commit `cde5190`, "Drop `aiosmtpd` and `wheel` from direct build deps"), which is currently the only contribution not yet acknowledged in `AUTHORS`.
- Email used (`wk.cvs.github@sydorenko.org.ua`) matches the author identity that landed on `main` via the squash merge of PR #41.

## Test plan

- [ ] `AUTHORS` renders cleanly (visual check on the PR's "Files changed" tab)
- [ ] `Tests` workflow stays green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)